### PR TITLE
修复发送群通知和添加联系人通知失败

### DIFF
--- a/src/routes/friendship.js
+++ b/src/routes/friendship.js
@@ -57,7 +57,7 @@ sendContactNotification = function(userId, nickname, friendId, operation, messag
     }
   };
   Utility.log('Sending ContactNotificationMessage:', JSON.stringify(contactNotificationMessage));
-  return rongCloud.message.system.publish(encodedUserId, [encodedFriendId], 'RC:ContactNtf', contactNotificationMessage, function(err, resultText) {
+  return rongCloud.message.system.publish(encodedUserId, [encodedFriendId], 'RC:ContactNtf', JSON.stringify(contactNotificationMessage), function(err, resultText) {
     if (err) {
       return Utility.logError('Error: send contact notification failed: %j', err);
     }

--- a/src/routes/group.js
+++ b/src/routes/group.js
@@ -73,7 +73,7 @@ sendGroupNotification = function(userId, groupId, operation, data) {
   };
   Utility.log('Sending GroupNotificationMessage:', JSON.stringify(groupNotificationMessage));
   return new Promise(function(resolve, reject) {
-    return rongCloud.message.group.publish('__system__', encodedGroupId, 'RC:GrpNtf', groupNotificationMessage, function(err, resultText) {
+    return rongCloud.message.group.publish('__system__', encodedGroupId, 'RC:GrpNtf', JSON.stringify(groupNotificationMessage), function(err, resultText) {
       if (err) {
         Utility.logError('Error: send group notification failed: %s', err);
         reject(err);


### PR DESCRIPTION
###  运行环境
node 版本: v8.9.3
MacOS High Sierra

### 修复 BUG
* 修复发送群通知时，提示错误代码 `http code 400`,提示 `content` 为必填参数
* 点击添加好友时，触发发送添加好友通知发送失败